### PR TITLE
fix: localhost等の未登録IPを国内扱いにし、LogRedirectJobのDI競合を解消

### DIFF
--- a/app/jobs/log_redirect_job.rb
+++ b/app/jobs/log_redirect_job.rb
@@ -1,20 +1,11 @@
 class LogRedirectJob < ApplicationJob
   queue_as :default
 
-  def initialize(
-    redirect_log_service: RedirectLogService.new,
-    shortened_url_repository: ShortenedUrlRepository.new
-  )
-    super()
-    @redirect_log_service = redirect_log_service
-    @shortened_url_repository = shortened_url_repository
-  end
-
   def perform(shortened_url_id:, ip_address:, user_agent:, referer:)
-    url = @shortened_url_repository.find_by_id(shortened_url_id)
+    url = ShortenedUrlRepository.new.find_by_id(shortened_url_id)
     return unless url
 
-    @redirect_log_service.create_redirect_log(
+    RedirectLogService.new.create_redirect_log(
       url,
       ip_address: ip_address,
       user_agent: user_agent,

--- a/app/services/ip_address_service.rb
+++ b/app/services/ip_address_service.rb
@@ -44,8 +44,11 @@ class IpAddressService
 
     begin
       result = @maxmind_country.get(ip)
-      Rails.logger.info "IP: #{ip}, Country: #{result&.dig('country', 'iso_code')}"
-      result&.dig("country", "iso_code") != "JP"
+      country_code = result&.dig("country", "iso_code")
+      Rails.logger.info "IP: #{ip}, Country: #{country_code}"
+      return false if country_code.nil?
+
+      country_code != "JP"
     rescue => e
       Rails.logger.error "Error checking overseas IP #{ip}: #{e.message}"
       true

--- a/spec/jobs/log_redirect_job_spec.rb
+++ b/spec/jobs/log_redirect_job_spec.rb
@@ -1,15 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe LogRedirectJob, type: :job do
-  let(:redirect_log_service)      { instance_double(RedirectLogService) }
-  let(:shortened_url_repository)  { instance_double(ShortenedUrlRepository) }
-  let(:job) do
-    described_class.new(
-      redirect_log_service: redirect_log_service,
-      shortened_url_repository: shortened_url_repository
-    )
-  end
+  let(:redirect_log_service)     { instance_double(RedirectLogService) }
+  let(:shortened_url_repository) { instance_double(ShortenedUrlRepository) }
   let(:shortened_url) { ShortenedUrl.new(id: 1, original_url: 'https://example.com', short_code: 'ABC123') }
+
+  before do
+    allow(RedirectLogService).to receive(:new).and_return(redirect_log_service)
+    allow(ShortenedUrlRepository).to receive(:new).and_return(shortened_url_repository)
+  end
 
   describe '#perform' do
     let(:args) do
@@ -28,7 +27,7 @@ RSpec.describe LogRedirectJob, type: :job do
       end
 
       it 'delegates to RedirectLogService' do
-        job.perform(**args)
+        described_class.new.perform(**args)
         expect(redirect_log_service).to have_received(:create_redirect_log).with(
           shortened_url,
           ip_address: '203.0.113.1',
@@ -44,8 +43,8 @@ RSpec.describe LogRedirectJob, type: :job do
       end
 
       it 'does nothing without raising' do
-        expect { job.perform(**args) }.not_to raise_error
         expect(redirect_log_service).not_to receive(:create_redirect_log)
+        expect { described_class.new.perform(**args) }.not_to raise_error
       end
     end
   end

--- a/spec/services/ip_address_service_spec.rb
+++ b/spec/services/ip_address_service_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe IpAddressService, type: :service do
         allow(mock_country_db).to receive(:get).with('1.1.1.1').and_return(nil)
       end
 
-      it 'returns true for nil result' do
-        expect(service.overseas_ip?('1.1.1.1')).to be true
+      it 'returns false for nil result (private/unknown IPs are treated as domestic)' do
+        expect(service.overseas_ip?('1.1.1.1')).to be false
       end
     end
   end


### PR DESCRIPTION
- IpAddressService#overseas_ip? で MaxMind DB が nil を返す場合（ローカルIP等）を false（国内）として扱う
- LogRedirectJob の initialize DI を削除（ActiveJob の perform_later と引数が衝突するため）
- 上記変更に合わせてテストを更新