### PR TITLE
fix: CF-Connecting-IP ヘッダーで実クライアント IP を取得する

### DIFF
--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -18,7 +18,7 @@ class RedirectsController < ApplicationController
     shortened_url = @shortened_url_service.find_by_short_code(short_code)
 
     if shortened_url
-      ip = request.remote_ip
+      ip = request.headers["CF-Connecting-IP"].presence || request.remote_ip
 
       if @crawler_service.search_engine_crawler?(request.user_agent)
         Rails.logger.info "Crawler access to short_code: #{short_code} by #{@crawler_service.identify_crawler(request.user_agent)}"


### PR DESCRIPTION
Railway のロードバランサー IP が request.remote_ip に入り
Cloudflare トラスト設定が効かない問題を解消。
Cloudflare が保証する CF-Connecting-IP を優先して使用する。